### PR TITLE
review: changes in docs and HSTS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Django REST Boilerplate
 
-A generic Docker-based Django solution for RESTful APIs and accompanying javascript applications. 
+A generic Docker-based Django solution for RESTful APIs and accompanying JavaScript applications.
 
 ## Getting Started
 
 ### Docker 
-This project uses Docker CE and docker-compose to run all services. [Installing docker](https://docs.docker.com/engine/installation/#supported-platforms)
-depends on the platform and is hence not included here. Docker-compose has to be [installed separately](https://docs.docker.com/compose/install/).
+This project uses Docker CE and Docker Compose to run all services. [Installing Docker](https://docs.docker.com/engine/installation/#supported-platforms)
+depends on the platform and is hence not included here. Docker Compose has to be [installed separately](https://docs.docker.com/compose/install/).
  
 ### Source Code
 To obtain the source code, please clone this repository.
@@ -19,24 +19,24 @@ Runnig django-rest-boilerplate requires a fully configured `.env` file. A templa
  - `BOILERPLATE_DOMAIN`: the domain name of the service provided
  - `BOILERPLATE_IPV4_16PREFIX`: internal network IPv4 address prefix. The default value `172.16` will suit most users.
  - `BOILERPLATE_IPV6_SUBNET`: internal network IPv6 subnet. The default value `bade:affe:dead:beef:b011::/80` will suit most users. 
- - `BOILERPLATE_IPV6_ADDRESS`: internal network IPv6 subnet. The default value `bade:affe:dead:beef:b011:0642:ac10:0080` will suit most users.
- - `BOILERPLATE_WWW_CERTS`: location of the required SSL certificates in PEM format. This folder needs to contain four files (see below). 
+ - `BOILERPLATE_IPV6_ADDRESS`: internal network IPv6 address. The default value `bade:affe:dead:beef:b011:0642:ac10:0080` will suit most users.
+ - `BOILERPLATE_WWW_CERTS`: location of the required SSL certificates in PEM format. This folder needs to contain the following four files:
     * `MAIN.cer`, `MAIN.key`: certificate and private key for `BOILERPLATE_DOMAIN`.
     * `www.cer`, `www.key`: certificate and private key for www. `BOILERPLATE_DOMAIN`.
     
-    The certificates can be obtained any way (and can also be the same). Please [see below for an convenient way](#dedyn.io-cert) to obtain debug certificates for `BOILERPLATE_DOMAIN` (but lacking a valid certificate for www. `BOILERPLATE_DOMAIN`). Alternatively, you can also [use self-sign certificates](https://github.com/desec-io/easypki).
- - `BOILERPLATE_API_SECRETKEY`: needs to be set to an instance specific [random secret value](https://www.random.org/passwords/?num=5&len=24&format=html&rnd=new).
- - `BOILERPLATE_DB_PASSWORD`: the database user password, should also be set to a instance specific random secret value.
+    The certificates can be obtained any way (and can also be the same). Please [see below for an convenient way](#dedyn.io-cert) to obtain debug certificates for `BOILERPLATE_DOMAIN` (but lacking a valid certificate for www.`BOILERPLATE_DOMAIN`). Alternatively, you can also [use self-signed certificates](https://github.com/desec-io/easypki).
+ - `BOILERPLATE_API_SECRETKEY`: needs to be set to an instance-specific [random secret value](https://www.random.org/passwords/?num=5&len=24&format=html&rnd=new).
+ - `BOILERPLATE_DB_PASSWORD`: the database user password, should also be set to an instance-specific random secret value.
 
 After populating `.env` with all appropriate values, the service can be started with
 
     docker-compose up
     
-and be reached at your chosen domain name (remember to have your domain name point at localhost). At http://example.com/api/admin/ is the generic django administration backend available.
+and be reached at your chosen domain name (remember to have your domain name point at localhost). At http://example.com/api/admin/, the generic Django administration backend is available.
 
 ### Django Management Console
 
-Many development tasks require the django management console, which can be reached though the `exec` command of docker-compose. A typical example includes creating the django superuser to first login to django.
+Many development tasks require the django management console, which can be reached though the `exec` command of docker-compose. A typical example includes creating the django superuser to first login to Django.
 
     docker-compose exec api python manage.py createsuperuser
     
@@ -52,31 +52,33 @@ To access the database directly, use
   
 (No password required.)
 
-The database is stored in a docker volume and hence persistent even if containers or images are newly built. To reset the database, use the docker-compose `down` command, which will remove all containers, images, networks, and volumes.
+The database is stored in a Docker volume and hence persistent even if containers or images are newly built. To reset the database, use the docker-compose `down` command with the appropriate flag(s) to remove all containers, images, networks, and volumes:
 
     docker-compose down -v
     
 ## Project Design
 
-This project consists of a docker-compose project with four docker containers; it follows the "one service per container" pattern.
+This project consists of a Docker Compose project with four Docker containers; it follows the "one service per container" pattern.
 
 The containers are arranged as shown in this diagram. Inter-service communication is only permitted along the connections shown:
 
     (user) --- www --- api --- db
                   \--- static
 
-  - **The `www` container** accepts all incoming connections. It handels
+  - **The `www` container** accepts all incoming connections. It handles
     * forwarding the request to either the API or static servers,
     * transport layer security, and
     * rate limits.
     
     It is currently implemented using an `nginx` webserver.
-  - **The `static` container** serves static files. This can be a basic website advertising the API service or an involved javascript application designed for usage with the API. (It can also be easily removed entirely.)
-  - **The `api` container** contains the Django-implemented RESTful API implementation. It communicates with `www` through an `uwsgi` interface. It handles 
-    * routing of all requests with URL beginning in `https://$BOILERPLATE_DOMAIN/api/`,
+  - **The `static` container** serves static files. This can be a basic website advertising the API service or an involved JavaScript application designed for usage with the API. (It can also be easily removed entirely.)
+  - **The `api` container** contains the Django-implemented RESTful API implementation. As such, it handles
+    * routing of all requests with URL beginning with `https://$BOILERPLATE_DOMAIN/api/`,
     * authentication of these requests, and
     * providing requested data and/or updating the database accordingly.
-  - **The `db` container** provides the MySQL (MariaDB) database used by the `api`. It is the only container in our setup that uses a Docker volume to persistantly store data.
+
+    It communicates with `www` through an `uwsgi` interface.
+  - **The `db` container** provides the MySQL (MariaDB) database used by the `api`. It is the only container in our setup that uses a Docker volume to persistently store data.
 
 The detailed design of the single containers is quite involved. Please refer to their individual READMEs.
 
@@ -90,7 +92,7 @@ Afterwards, we instruct the production server to download the images and start c
 
 ### Step by Step Guide
 
-To deploy your project to the production server, first choose a name for the `image` options `docker-compose.yml` and register it with [Docker Hub](https://hub.docker.com/).
+To deploy your project to the production server, first customize the `image` options in `docker-compose.yml` with a proper name and register it with [Docker Hub](https://hub.docker.com/).
 After logging in to Docker Hub, compile all images on your development machine using
 
     docker-compose build --no-cache --pull
@@ -108,7 +110,7 @@ On your production machine, make sure that `.env` and `docker-compose.yml` are a
     docker-compose pull
     docker-compose up
     
-With the exception of registration with Docker Hub, the procedure is the same for updating your production server.
+For updating the production server, the procedure is the same (with the exception that the registration with Docker Hub does not need to be repeated.)
 Note that environment and database will be different on production and hence can cause complications during database migration upon service restart after the update.
 
 
@@ -137,11 +139,11 @@ Register a domain name of your choice at desec.io. After registration, you will 
 https://update.dedyn.io/update?username=<em>example.dedyn.io</em>&amp;password=<em>yourpassword</em>&amp;ip=172.16.0.128
 </pre>
 
-Then follow [their guide to obtain a Let's Encrypt certificate](https://desec.io/#!/en/docs/certbot). Notice that dedyn.io currently only supports certificate for `example.dedyn.io`, but not for any sub-domains.
+Then follow [their guide to obtain a Let's Encrypt certificate](https://desec.io/#!/en/docs/certbot). Notice that dedyn.io currently only supports certificates for `example.dedyn.io`, but not for any subdomains.
 
 After successfully obtaining the LE certificate, it will be placed in PEM format in `/etc/letsencrypt/live/example.dedyn.io/` and needs to be moved to the location specified above in `.env`.
 
-As dedyn.io currently does not support issuance of certificates for subdomains, we recommend using the (then invalid) `MAIN.cer` also for `www.cer`. This will result in a security warning when browsing to www. `BOILERPLATE_DOMAIN`. (However, nginx will not start without a certificate file for www.)
+As dedyn.io currently does not support issuance of certificates for subdomains, we recommend using the (then invalid) `MAIN.cer` also for `www.cer`. This will result in a security warning when browsing to www.`BOILERPLATE_DOMAIN`. (However, nginx will not start without a certificate file for www.)
 
 ## Getting Help
 Any Django questions are best answered by [their documentation and support channels](https://docs.djangoproject.com/en/1.11/).

--- a/api/README.md
+++ b/api/README.md
@@ -1,6 +1,6 @@
 # boilerplate Django REST API
 
-Any docker image build from this sources will contain a complete Django framework running an uwsgi service.
+Any Docker image built from these sources will contain a complete Django framework running an uwsgi service.
 
 ## Customization
 
@@ -21,8 +21,8 @@ The service obtains a couple of crucial settings from environment variables, suc
 
 ## Building this Image
 
-When build, this image installs some `mysql` dependencies and tools onto the Python 3.6 Docker image, then copies the Django app source code into the image and installs the `pip` requirements. Compatible updates to any `pip` requirements are automatically installed on each build (unless the build is cached).
+At build time, this image installs some `mysql` dependencies and tools onto the Python 3.6 Docker image, then copies the Django app source code into the image and installs the `pip` requirements. Compatible updates to any `pip` requirements are automatically installed on each build (unless the build is cached).
 
 ## Starting a Container
 
-When started, `entrypoint.sh` is executed. It connects to the database and executes Django database migration if necessary. Afterwards, the Django uswgi service is started. Note that this service is not inteded to be exposed to the public, doing so may yield unintended consequences.
+When started, `entrypoint.sh` is executed. It connects to the database and executes Django database migration if necessary. Afterwards, the Django uswgi service is started. Note that this service is not inteded to be exposed to the public, and doing so may yield unintended consequences.

--- a/db/README.md
+++ b/db/README.md
@@ -1,6 +1,6 @@
 # boilerplate MariaDB Server
 
-Any docker image build from this sources will provide a custom configured MariaDB service.
+Any Docker image build from these sources will provide a custom configured MariaDB service.
 
 ## Customization
 
@@ -20,12 +20,12 @@ Upon starting the container for the first time, an empty database `api` will be 
 
 ### Volume
 
-All database values are stored on a docker volume and are hence persistant when replacing the image or container.
+All database values are stored on a Docker volume and are hence persistent when replacing the image or container.
 
 
 ## Building this Image
 
-Database initialization scripts are copied onto the image when building. Note that they will not be executed during build time, as they depend on environment variables that will only be available during run time. Any change to the initialization scripts need a rebuild to become effective.
+Database initialization scripts are copied into the image when building. Note that they will not be executed during build time, as they depend on environment variables that will only be available during run time. Any change to the initialization scripts necessitates a rebuild to become effective.
 
 ## Starting a Container
 

--- a/static/README.md
+++ b/static/README.md
@@ -1,10 +1,10 @@
 # boilerplate Static HTTP Server
 
-Any docker image build from this sources will provide a basic (nginx) HTTP service providing all files from the `html` folder to all requests forwarded to the server (currently, that's all requests to the service unless the `/api` prefix is used). This service is intended to serve an informative webpage or a javascript-implemented browser API client.
+Any Docker image build from these sources will provide a basic (nginx) HTTP service providing all files from the `html` folder to all requests forwarded to the server (currently, that's all requests to the service unless the `/api` prefix is used, per configuration of the `www` container). This service is intended to serve an informative webpage or a JavaScript-implemented browser API client.
 
 ## Building this Image
 
-Upon build, all files from the `html/` folder are copied onto the image. This image will use the currently stable `nginx` version.
+Upon build, all files from the `html/` folder are copied into the image. This image will use the currently stable `nginx` version.
 
 ## Starting the Container
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,6 +1,6 @@
 # End to End Tests
 
-These image source provide a docker container that automatically runs all tests against the REST API upon startup.
+These image sources provide a Docker container that automatically runs all tests against the REST API upon startup.
 
 To run the tests, use
 

--- a/www/README.md
+++ b/www/README.md
@@ -1,12 +1,12 @@
 # boilerplate www Server
 
-Any docker image build from this sources will provide the (nginx) HTTP server that is supposed to be the (only) frontend service for this REST API service.
+Any Docker image build from these sources will provide the (nginx) HTTP server that is supposed to be the (only) frontend service for this REST API service.
 
 ## Request Handling
 
 ### Allowed Hosts
 
-Request handling depends on the `Host` HTTP header provided by the client. First, all requests that are not for `$BOILERPLATE_DOMAIN` or `www.$BOILERPLATE_DOMAIN` will be answered with the somewhat special status code 444. (Although not being standard, this helps to easily identify those requests using the nginx log files.)
+Request handling depends on the `Host` HTTP header provided by the client. First, all requests that are not for `$BOILERPLATE_DOMAIN` or www.`$BOILERPLATE_DOMAIN` will be answered with the somewhat special status code 444. (Although not being standard, this helps to easily identify those requests using the nginx log files.)
 
 Second, all requests that are not using TLS or are not directed to `$BOILERPLATE_DOMAIN` (no `www` prefix) will be redirected to https://$BOILERPLATE_DOMAIN/, maintaining the originally requested path.
 
@@ -14,17 +14,17 @@ Third, requests to https://$BOILERPLATE_DOMAIN/api/ will be forwarded to the Dja
 
 ### Rate Limits
 
-Although this image is ready to rate limit requests, **the currently set limits are ridiculously high**. Rate limiting is handled seperatly for api and static requests, assuming api requests will usually be more expensive and should thus be limited stricter that static requests. Please refer to the configuration files for exact configuration.
+Although this image is ready to rate limit requests, **the currently set limits are ridiculously high**. Rate limiting is handled seperately for `api` and `static` requests, assuming `api` requests will usually be more expensive and should thus be limited more strictly than `static` requests. Please refer to the configuration files for exact configuration.
 
 ### TLS Certificates
 
-To authenticate this service to clients, nginx needs SSL certificates for `$BOILERPLATE_DOMAIN` and `www.$BOILERPLATE_DOMAIN`. To provide them, place two certificate-key-pairs into the directory specified in the according environment variable (the pairs can be identical, if you have one certificate with both names, but must be provided seperately).
+To authenticate this service to clients, nginx needs SSL certificates for `$BOILERPLATE_DOMAIN` and www.`$BOILERPLATE_DOMAIN`. To provide them, place two certificate-key-pairs into the directory specified in the according environment variable (the pairs can be identical, if you have one certificate for both names, but must be provided seperately).
 
-Note that all requests will be answered with an `HSTS` header to increase TLS usage.
+Note that all requests will be answered with an `HSTS` header to spread TLS usage.
 
 ## Building this Image
 
-Upon build, all configuration files are copied onto the image. Note that they still contain placeholders for variables that will only become available once a container is started. Nevertheless, updating the configuration files will make a rebuild necessary.
+Upon build, all configuration files are copied into the image. Note that they still contain placeholders for variables that will only become available once a container is started. Nevertheless, updating the configuration files will make a rebuild necessary.
 
 Note that the image will not contain any sensitive data such as certificates or even private keys.
 

--- a/www/conf/sites-available/10-redirects.conf.var
+++ b/www/conf/sites-available/10-redirects.conf.var
@@ -37,7 +37,7 @@ server {
 	include global.conf;
 	
 	location / {
-		add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
+		add_header Strict-Transport-Security "max-age=31536000";
 		return 301 https://$BOILERPLATE_DOMAIN$request_uri;
 	}
 }

--- a/www/conf/sites-available/20-static-and-api.conf.var
+++ b/www/conf/sites-available/20-static-and-api.conf.var
@@ -9,7 +9,7 @@ server {
 	ssl on;
 	ssl_certificate /etc/ssl/private/MAIN.cer;
 	ssl_certificate_key /etc/ssl/private/MAIN.key;
-	add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
+	add_header Strict-Transport-Security "max-age=31536000";
 	
 	include global.conf;
 	
@@ -22,7 +22,7 @@ server {
 		limit_req zone=perip-api burst=10 nodelay;
 		expires epoch;
 		etag off;
-		add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
+		add_header Strict-Transport-Security "max-age=31536000";
 		include uwsgi_params;
 		uwsgi_pass api;
 	}


### PR DESCRIPTION
Hey!

That's a lot of good work! 👍👍👍

I took a look at everything. As a result, this PR contains some suggestions for the README files, and also suggestions to remove `includeSubdomains` from the HSTS configuration. (It's unclear what else is served under the user's subdomains, and I think a conservative approach would be better in this case.)

Two questions:

- In `www/conf/sites-available/20-static-and-api.conf.var`, there is a server-wide HSTS header, and one for the `/api/` location. Is the second one required, or redundant? (This was probably copied from deSEC.)

- In `api/entrypoint.sh`, I saw that you added a call to `python manage.py collectstatic`. I am not an expert with Django static file handling, but as far as I understand, static files will also be served without `collectstatic`, given `urls.py` has the correct settings (which seems to be the case). However, serving static files through Django is inefficient, and the [Django docs](https://docs.djangoproject.com/en/1.11/howto/static-files/deployment/#serving-the-site-and-your-static-files-from-the-same-server) recommend that it should be done through the frontend web server. `collectstatic` then helps collecting everything into a directory that the frontend server can serve. However, the static directory is currenlty not connected to the `static` or `www` containers. So, what's the purpose of calling `collectstatic`? (There is another use case when hosting multiple Django apps, but that is also not the case here.)

Related to the second question: Could we cook up some shared volume to which `collectstatic` writes, and from which the `static` container servers?