### PR TITLE
Docker forward compatibility

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,8 +1,6 @@
 FROM python:3.6
 
 RUN apt-get update && apt-get install -y \
-#		gcc \
-#		gettext \
 		mysql-client libmysqlclient-dev \
 		postgresql-client libpq-dev \
 		sqlite3 \


### PR DESCRIPTION
With docker v1.13 comments are no longer allowed to be inside the RUN statement.

(--> https://github.com/moby/moby/issues/29005)